### PR TITLE
use vis-wisdom; remove (1) from unit name

### DIFF
--- a/units/vis-basics.yml
+++ b/units/vis-basics.yml
@@ -14,3 +14,4 @@ readings:
     This chapter will give you the basics of ggplot2, allowing to create
     simple, but informative, plots.
 - book: vis-wisdom-1
+

--- a/units/vis-basics.yml
+++ b/units/vis-basics.yml
@@ -1,8 +1,8 @@
-title: Visualisation basics
+title: Visualization basics
 theme: visualize
 
 desc: |
-  Data visualisation is one of the most important tools of data science.
+  Data visualization is one of the most important tools of data science.
   It's also a great place to start learning a programming language because
   you get an immediate payoff that will help you keep motivated as you push
   through initial frustrations.

--- a/units/vis-basics.yml
+++ b/units/vis-basics.yml
@@ -1,4 +1,4 @@
-title: Visualization basics
+title: Visualisation basics
 theme: visualize
 
 desc: |
@@ -11,17 +11,6 @@ needs: [data-basics]
 
 readings:
 - text: >
-    These sections will give you the basics of ggplot2, allowing to create
+    This chapter will give you the basics of ggplot2, allowing to create
     simple, but informative, plots.
-- book: r4ds-3.3
-- book: r4ds-3.4
-- book: r4ds-3.5
-- book: r4ds-3.6
-
-- text: >
-    Skim the following resources so you're aware of the most important ggplot2
-    geoms. Come back and read in detail when you actually need to use them.
-- book: ggplot2-3
-- book: cheatsheets-data-visualization-2.1
-- href: http://ggplot2.tidyverse.org/reference/index.html#section-layer-geoms
-  text: ggplot2 documentation
+- book: vis-wisdom-1


### PR DESCRIPTION
I deleted the supplemental resources because:
* we link to the cheat sheet from vis-wisdom
* I didn't think there was much in the ggplot2 book/documentation that would be useful to students at this time. Maybe we can link later to show them where these exist? If they are useful, maybe we should just link to them from vis-wisdom

also changes "visualisation" -> "visualization" in one place